### PR TITLE
Update import sorting rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,17 @@ export default tseslint.config(
         {
           type: "natural",
           order: "asc",
+          newlinesBetween: 'never',          
+          groups: [
+            ["builtin-type", "builtin"],
+            ["external-type", "external"],
+            ["internal-type", "internal"],
+            ["parent-type", "parent"],
+            ["sibling-type", "sibling"],
+            ["index-type", "index"],
+            "object",
+            "unknown"
+          ]
         },
       ],
       "perfectionist/sort-exports": [
@@ -134,7 +145,10 @@ export default tseslint.config(
       ],
       "@typescript-eslint/consistent-type-imports": [
         "error",
-        { prefer: "type-imports" },
+        {
+          prefer: "type-imports",
+          fixStyle: "inline-type-imports"
+        },
       ],
       "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-misused-promises": "error",


### PR DESCRIPTION
Current rules may cause errors with duplicated imports that are impossible to fix, like with the code [from here](https://github.com/GramyPomagamy/gsps-remote-highlighter/pull/1).

Old rules:
![image](https://github.com/user-attachments/assets/66f42a3d-2b5a-4094-949f-83582d279ffb)

New rules:
![Screenshot From 2025-06-10 00-48-21](https://github.com/user-attachments/assets/de130347-aeba-4a36-9cc2-9c7de0a69793)

Also disallows empty lines between import groups
