### PR TITLE
3.0.0 - add Prettier & Vue rules, split base configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,17 +117,4 @@ ESLint is enabled by default in WebStorm, the only recommended tweak is enabling
 
 ### Zed
 
-ESLint is installed by default in Zed. Add this snippet to your config:
-```json
-  "format_on_save": "on",
-  "formatter": [
-    {
-      "code_actions": {
-        "source.fixAll.eslint": true
-      }
-    }
-  ]
-```
-to enable format on save for ESLint.
-
-More info here: https://zed.dev/docs/configuring-zed#format-on-save
+ESLint is installed by default in Zed. In the settings go to Editor, and turn on Format on Save. 

--- a/README.md
+++ b/README.md
@@ -70,3 +70,20 @@ This enable fix on save in VSCode for ESLint.
 ### JetBrains WebStorm
 
 ESLint is enabled by default in WebStorm, the only recommended tweak is enabling ["fix on save" in ESLint settings](https://www.jetbrains.com/help/webstorm/eslint.html#ws_eslint_configure_run_eslint_on_save).
+
+### Zed
+
+ESLint is installed by default in Zed. Add this snippet to your config:
+```json
+  "format_on_save": "on",
+  "formatter": [
+    {
+      "code_actions": {
+        "source.fixAll.eslint": true
+      }
+    }
+  ]
+```
+to enable format on save for ESLint.
+
+More info here: https://zed.dev/docs/configuring-zed#format-on-save

--- a/README.md
+++ b/README.md
@@ -10,19 +10,29 @@ npm i -D @gramypomagamy/eslint-config
 ```
 
 ### Base config
-The base config is suitable for most projects with a single `tsconfig.json` file.
+This package includes 3 base configs:
+- one for raw TypeScript (exported as `tsConfig`)
+- one for React (exported as `reactConfig`)
+- one for Vue (exported as `vueConfig`)
 
 Add a file called `eslint.config.mjs` to your project root, and add this code there:
 ```js
-import { baseConfig } from '@gramypomagamy/eslint-config';
+import { tsConfig } from '@gramypomagamy/eslint-config';
 
-export default baseConfig;
+export default tsConfig;
 ```
 
-### Config creator (mostly used for NodeCG projects)
+These configs can be combined if needed, like this:
+```js
+import { tsConfig, reactConfig } from '@gramypomagamy/eslint-config';
+
+export default [...tsConfig, ...reactConfig];
+```
+
+### Config creator
 The config creator allows you to create specific rules with custom paths to the files that would be linted and a custom path to a `tsconfig.json` file.
 
-Example usage:
+Example usage for React:
 ```js
 import { ConfigCreator } from "@gramypomagamy/eslint-config";
 
@@ -33,15 +43,49 @@ const tsParser = ConfigCreator.createTsParser({
   ],
 });
 
-const browserConfig = ConfigCreator.createBrowserRules({
+const browserConfig = ConfigCreator.createReactRules({
   folderPath: "src/browser",
 });
 
-const browserTsConfig = ConfigCreator.createNodeRules({
+const browserTsConfig = ConfigCreator.createTsRules({
   folderPath: "src/browser",
 });
 
-const extensionConfig = ConfigCreator.createNodeRules({
+const extensionConfig = ConfigCreator.createTsRules({
+  folderPath: "src/extension",
+});
+
+export default [
+  ...tsParser,
+  ...browserConfig,
+  ...browserTsConfig,
+  ...extensionConfig,
+];
+```
+
+Example usage for Vue:
+```js
+import { ConfigCreator } from "@gramypomagamy/eslint-config";
+
+const tsParser = ConfigCreator.createTsParser({
+  tsconfigFilePaths: [
+    "src/browser/tsconfig.json",
+    "src/extension/tsconfig.json",
+  ],
+});
+
+const browserConfig = ConfigCreator.createVueRules({
+  folderPath: "src/browser",
+  tsconfigFilePaths: [
+    "src/browser/tsconfig.json",
+  ],
+});
+
+const browserTsConfig = ConfigCreator.createTsRules({
+  folderPath: "src/browser",
+});
+
+const extensionConfig = ConfigCreator.createTsRules({
   folderPath: "src/extension",
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,13 @@
       "dependencies": {
         "@stylistic/eslint-plugin": "~5.2.3",
         "eslint": "~9.33.0",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-perfectionist": "~4.15.0",
+        "eslint-plugin-prettier": "^5.5.4",
         "eslint-plugin-react": "~7.37.5",
         "eslint-plugin-react-hooks": "~5.2.0",
         "globals": "~16.3.0",
+        "prettier": "~3.6.2",
         "typescript-eslint": "~8.39.1"
       },
       "devDependencies": {
@@ -24,7 +27,8 @@
         "typescript": "^5.9.2"
       },
       "peerDependencies": {
-        "eslint": "~9.33.0"
+        "eslint": "~9.33.0",
+        "prettier": "~3.6.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -797,6 +801,18 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2244,6 +2260,21 @@
         }
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-plugin-perfectionist": {
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-4.15.0.tgz",
@@ -2259,6 +2290,36 @@
       },
       "peerDependencies": {
         "eslint": ">=8.45.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
+      "integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -2406,6 +2467,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -3914,6 +3981,33 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4706,6 +4800,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
       }
     },
     "node_modules/thenify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,16 @@
       "dependencies": {
         "@stylistic/eslint-plugin": "~5.2.3",
         "eslint": "~9.33.0",
-        "eslint-config-prettier": "^10.1.8",
+        "eslint-config-prettier": "~10.1.8",
         "eslint-plugin-perfectionist": "~4.15.0",
-        "eslint-plugin-prettier": "^5.5.4",
+        "eslint-plugin-prettier": "~5.5.4",
         "eslint-plugin-react": "~7.37.5",
         "eslint-plugin-react-hooks": "~5.2.0",
+        "eslint-plugin-vue": "~10.5.0",
         "globals": "~16.3.0",
         "prettier": "~3.6.2",
-        "typescript-eslint": "~8.39.1"
+        "typescript-eslint": "~8.39.1",
+        "vue-eslint-parser": "~10.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.17.1",
@@ -1631,6 +1633,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1830,6 +1838,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/data-view-buffer": {
@@ -2373,6 +2393,37 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-vue": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.5.0.tgz",
+      "integrity": "sha512-7BZHsG3kC2vei8F2W8hnfDi9RK+cv5eKPMvzBdrl8Vuc0hR5odGQRli8VVzUkrmUHkxFEm4Iio1r5HOKslO0Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "natural-compare": "^1.4.0",
+        "nth-check": "^2.1.1",
+        "postcss-selector-parser": "^6.0.15",
+        "semver": "^7.6.3",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+        "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "vue-eslint-parser": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@stylistic/eslint-plugin": {
+          "optional": true
+        },
+        "@typescript-eslint/parser": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {
@@ -3647,6 +3698,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3970,6 +4033,19 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/prelude-ls": {
@@ -5172,6 +5248,35 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vue-eslint-parser": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.2.0.tgz",
+      "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.6.0",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -5393,6 +5498,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -37,14 +37,18 @@
   "dependencies": {
     "@stylistic/eslint-plugin": "~5.2.3",
     "eslint": "~9.33.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-perfectionist": "~4.15.0",
+    "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-react": "~7.37.5",
     "eslint-plugin-react-hooks": "~5.2.0",
     "globals": "~16.3.0",
+    "prettier": "~3.6.2",
     "typescript-eslint": "~8.39.1"
   },
   "peerDependencies": {
-    "eslint": "~9.33.0"
+    "eslint": "~9.33.0",
+    "prettier": "~3.6.2"
   },
   "devDependencies": {
     "@types/node": "^22.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gramypomagamy/eslint-config",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "main": "./dist/index.cjs",
   "type": "module",
   "description": "ESLint configuration used in GSPS (GramyPomagamy) TypeScript projects.",

--- a/package.json
+++ b/package.json
@@ -37,14 +37,16 @@
   "dependencies": {
     "@stylistic/eslint-plugin": "~5.2.3",
     "eslint": "~9.33.0",
-    "eslint-config-prettier": "^10.1.8",
+    "eslint-config-prettier": "~10.1.8",
     "eslint-plugin-perfectionist": "~4.15.0",
-    "eslint-plugin-prettier": "^5.5.4",
+    "eslint-plugin-prettier": "~5.5.4",
     "eslint-plugin-react": "~7.37.5",
     "eslint-plugin-react-hooks": "~5.2.0",
+    "eslint-plugin-vue": "~10.5.0",
     "globals": "~16.3.0",
     "prettier": "~3.6.2",
-    "typescript-eslint": "~8.39.1"
+    "typescript-eslint": "~8.39.1",
+    "vue-eslint-parser": "~10.2.0"
   },
   "peerDependencies": {
     "eslint": "~9.33.0",

--- a/src/base.ts
+++ b/src/base.ts
@@ -4,19 +4,21 @@ const tsParser = ConfigCreator.createTsParser({
   tsconfigFilePaths: ["tsconfig.json"],
 });
 
-const browserRules = ConfigCreator.createBrowserRules({
+const reactRules = ConfigCreator.createReactRules({
   folderPath: "**",
 });
 
-const extensionRules = ConfigCreator.createNodeRules({
+const vueRules = ConfigCreator.createVueRules({
+  folderPath: "**",
+  tsconfigFilePaths: ["tsconfig.json"],
+});
+
+const tsRules = ConfigCreator.createTsRules({
   folderPath: "**",
 });
 
 const testRules = ConfigCreator.createTestRules();
 
-export const baseConfig = [
-  ...tsParser,
-  ...browserRules,
-  ...extensionRules,
-  ...testRules,
-];
+export const tsConfig = [...tsParser, ...tsRules, ...testRules];
+export const reactConfig = [...tsParser, ...reactRules, ...testRules];
+export const vueConfig = [...vueRules, ...testRules];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { baseConfig } from "./base.js";
+import { tsConfig, reactConfig, vueConfig } from "./base.js";
 import { ConfigCreator } from "./util/ConfigCreator.js";
 
-export { baseConfig, ConfigCreator };
+export { tsConfig, reactConfig, vueConfig, ConfigCreator };

--- a/src/util/ConfigCreator.ts
+++ b/src/util/ConfigCreator.ts
@@ -2,6 +2,8 @@ import eslintJs from "@eslint/js";
 import * as tseslint from "typescript-eslint";
 import perfectionist from "eslint-plugin-perfectionist";
 import * as reactHooks from "eslint-plugin-react-hooks";
+import prettier from 'eslint-plugin-prettier';
+import prettierConfig from 'eslint-config-prettier';
 import react from "eslint-plugin-react";
 import globals from "globals";
 import stylistic from "@stylistic/eslint-plugin";
@@ -51,7 +53,7 @@ export class ConfigCreator {
         files: [`${folderPath}/**/*.{js,mjs,cjs,ts}`],
         plugins: {
           perfectionist,
-          "@stylistic": stylistic,
+          prettier,
         },
         languageOptions: {
           globals: {
@@ -75,31 +77,6 @@ export class ConfigCreator {
           "prefer-const": "error",
           yoda: "error",
           eqeqeq: ["error", "smart"],
-
-          // eslint-stylistic
-          "@stylistic/newline-per-chained-call": "error",
-          "@stylistic/semi": "error",
-          "@stylistic/eol-last": "error",
-          "@stylistic/indent": ["error", 2],
-          "@stylistic/brace-style": ["error", "1tbs"],
-          "@stylistic/array-bracket-newline": ["error", "consistent"],
-          "@stylistic/object-curly-spacing": ["error", "always"],
-          "@stylistic/quotes": ["error", "double", { avoidEscape: true }],
-          "@stylistic/max-len": [
-            "warn",
-            {
-              code: 100,
-              ignoreStrings: true,
-              ignoreTemplateLiterals: true,
-              ignoreComments: true,
-            },
-          ],
-          "@stylistic/no-trailing-spaces": "error",
-          "@stylistic/no-multi-spaces": "error",
-          "@stylistic/no-multiple-empty-lines": [
-            "error",
-            { max: 1, maxEOF: 0 },
-          ],
 
           // perfectionist
           "perfectionist/sort-imports": [
@@ -132,6 +109,9 @@ export class ConfigCreator {
             "warn",
             { type: "natural", order: "asc" },
           ],
+
+          // prettier
+          "prettier/prettier": "error",
         },
       },
 
@@ -192,7 +172,9 @@ export class ConfigCreator {
           "@typescript-eslint/no-use-before-define": "error",
           "@typescript-eslint/no-require-imports": "off",
         },
-      }
+      },
+
+      prettierConfig
     );
   }
 
@@ -208,6 +190,7 @@ export class ConfigCreator {
         plugins: {
           react,
           perfectionist,
+          prettier,
           "@stylistic": stylistic,
         },
         settings: {
@@ -225,7 +208,6 @@ export class ConfigCreator {
         rules: {
           "no-duplicate-imports": "error",
           "no-use-before-define": "off",
-          curly: "error",
           "default-case": "error",
           "dot-notation": "error",
           "no-empty-function": "off",
@@ -236,31 +218,6 @@ export class ConfigCreator {
           "prefer-const": "error",
           yoda: "error",
           eqeqeq: ["error", "smart"],
-
-          // eslint-stylistic
-          "@stylistic/newline-per-chained-call": "error",
-          "@stylistic/semi": "error",
-          "@stylistic/eol-last": "error",
-          "@stylistic/indent": ["error", 2],
-          "@stylistic/brace-style": ["error", "1tbs"],
-          "@stylistic/array-bracket-newline": ["error", "consistent"],
-          "@stylistic/object-curly-spacing": ["error", "always"],
-          "@stylistic/quotes": ["error", "double", { avoidEscape: true }],
-          "@stylistic/max-len": [
-            "warn",
-            {
-              code: 100,
-              ignoreStrings: true,
-              ignoreTemplateLiterals: true,
-              ignoreComments: true,
-            },
-          ],
-          "@stylistic/no-trailing-spaces": "error",
-          "@stylistic/no-multi-spaces": "error",
-          "@stylistic/no-multiple-empty-lines": [
-            "error",
-            { max: 1, maxEOF: 0 },
-          ],
 
           // perfectionist
           "perfectionist/sort-imports": [
@@ -309,8 +266,6 @@ export class ConfigCreator {
           "react/jsx-boolean-value": ["error", "never"],
 
           // JSX stylistic
-          "@stylistic/jsx-quotes": ["error", "prefer-double"],
-          "@stylistic/jsx-indent-props": ["error", 2],
           "@stylistic/jsx-self-closing-comp": [
             "error",
             {
@@ -319,9 +274,6 @@ export class ConfigCreator {
             },
           ],
           "@stylistic/jsx-pascal-case": ["error", { allowNamespace: true }],
-          "@stylistic/jsx-closing-tag-location": "error",
-          "@stylistic/jsx-curly-spacing": ["error", { when: "never" }],
-          "@stylistic/jsx-first-prop-new-line": ["error", "multiline"],
           "@stylistic/jsx-curly-brace-presence": [
             "error",
             {
@@ -330,6 +282,9 @@ export class ConfigCreator {
               propElementValues: "always",
             },
           ],
+
+          // prettier
+          "prettier/prettier": "error",
         },
       },
 
@@ -388,7 +343,9 @@ export class ConfigCreator {
           "@typescript-eslint/no-use-before-define": "error",
           "@typescript-eslint/no-require-imports": "off",
         },
-      }
+      },
+
+      prettierConfig
     );
   }
 
@@ -411,6 +368,8 @@ export class ConfigCreator {
         "@stylistic/max-len": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
       },
-    });
+    },
+      prettierConfig
+    );
   }
 }

--- a/src/util/ConfigCreator.ts
+++ b/src/util/ConfigCreator.ts
@@ -160,7 +160,6 @@ export class ConfigCreator {
             {
               selector: "interface",
               format: ["PascalCase"],
-              prefix: ["I"],
             },
             {
               selector: "typeAlias",
@@ -344,7 +343,6 @@ export class ConfigCreator {
             {
               selector: "interface",
               format: ["PascalCase"],
-              prefix: ["I"],
             },
             {
               selector: "typeAlias",
@@ -474,7 +472,6 @@ export class ConfigCreator {
             {
               selector: "interface",
               format: ["PascalCase"],
-              prefix: ["I"],
             },
             {
               selector: "typeAlias",

--- a/src/util/ConfigCreator.ts
+++ b/src/util/ConfigCreator.ts
@@ -412,6 +412,9 @@ export class ConfigCreator {
           },
         },
         rules: {
+          // vue
+          "vue/multi-word-component-names": "off",
+
           // perfectionist
           "perfectionist/sort-imports": [
             "error",

--- a/src/util/ConfigCreator.ts
+++ b/src/util/ConfigCreator.ts
@@ -2,9 +2,11 @@ import eslintJs from "@eslint/js";
 import * as tseslint from "typescript-eslint";
 import perfectionist from "eslint-plugin-perfectionist";
 import * as reactHooks from "eslint-plugin-react-hooks";
-import prettier from 'eslint-plugin-prettier';
-import prettierConfig from 'eslint-config-prettier';
+import prettier from "eslint-plugin-prettier";
+import prettierConfig from "eslint-config-prettier";
 import react from "eslint-plugin-react";
+import vue from "eslint-plugin-vue";
+import vueParser from "vue-eslint-parser";
 import globals from "globals";
 import stylistic from "@stylistic/eslint-plugin";
 import type {
@@ -33,7 +35,7 @@ export class ConfigCreator {
     });
   }
 
-  public static createNodeRules({ folderPath }: LintingRulesParams) {
+  public static createTsRules({ folderPath }: LintingRulesParams) {
     return tseslint.config(
       {
         ignores: [
@@ -50,6 +52,7 @@ export class ConfigCreator {
       eslintJs.configs.recommended,
 
       {
+        name: "javascript-rules",
         files: [`${folderPath}/**/*.{js,mjs,cjs,ts}`],
         plugins: {
           perfectionist,
@@ -116,6 +119,7 @@ export class ConfigCreator {
       },
 
       {
+        name: "typescript-rules",
         files: [`${folderPath}/**/*.ts`],
         plugins: {
           "@typescript-eslint": tseslint.plugin,
@@ -174,13 +178,25 @@ export class ConfigCreator {
         },
       },
 
-      prettierConfig
+      prettierConfig,
     );
   }
 
-  public static createBrowserRules({ folderPath }: LintingRulesParams) {
+  public static createReactRules({ folderPath }: LintingRulesParams) {
     return tseslint.config(
       {
+        ignores: [
+          "node_modules",
+          ".gitignore",
+          "dist",
+          "build",
+          "coverage",
+          ".next",
+          "*.min.js",
+        ],
+      },
+      {
+        name: "react-rules",
         files: [`${folderPath}/**/*.{jsx,tsx}`],
         extends: [
           react.configs.flat.recommended,
@@ -289,6 +305,7 @@ export class ConfigCreator {
       },
 
       {
+        name: "react-rules-typescript",
         files: [`${folderPath}/**/*.tsx`],
         plugins: {
           "@typescript-eslint": tseslint.plugin,
@@ -345,31 +362,164 @@ export class ConfigCreator {
         },
       },
 
-      prettierConfig
+      prettierConfig,
+    );
+  }
+
+  public static createVueRules({
+    folderPath,
+    tsconfigFilePaths,
+  }: LintingRulesParams & TsParserParams) {
+    return tseslint.config(
+      {
+        ignores: [
+          "node_modules",
+          ".gitignore",
+          "dist",
+          "build",
+          "coverage",
+          ".next",
+          "*.min.js",
+        ],
+      },
+      {
+        name: "vue-rules",
+        files: [`${folderPath}/**/*.vue`],
+        extends: [
+          vue.configs["flat/recommended"],
+          tseslint.configs.recommended,
+        ],
+        plugins: {
+          vue,
+          prettier,
+          perfectionist,
+          "@typescript-eslint": tseslint.plugin,
+        },
+        settings: {
+          "import/resolver": {
+            typescript: {},
+          },
+        },
+        languageOptions: {
+          parser: vueParser,
+          parserOptions: {
+            parser: tseslint.parser,
+            project: tsconfigFilePaths,
+            extraFileExtensions: [".vue"],
+          },
+          globals: {
+            ...globals.node,
+            ...globals.es2021,
+            ...globals.browser,
+          },
+        },
+        rules: {
+          // perfectionist
+          "perfectionist/sort-imports": [
+            "error",
+            {
+              type: "natural",
+              order: "asc",
+              newlinesBetween: "never",
+              groups: [
+                ["builtin-type", "builtin"],
+                ["external-type", "external"],
+                ["internal-type", "internal"],
+                ["parent-type", "parent"],
+                ["sibling-type", "sibling"],
+                ["index-type", "index"],
+                "object",
+                "unknown",
+              ],
+            },
+          ],
+          "perfectionist/sort-exports": [
+            "error",
+            { type: "natural", order: "asc" },
+          ],
+          "perfectionist/sort-named-imports": [
+            "error",
+            { type: "natural", order: "asc" },
+          ],
+          "perfectionist/sort-object-types": [
+            "warn",
+            { type: "natural", order: "asc" },
+          ],
+
+          // typescript-eslint
+          "@typescript-eslint/prefer-nullish-coalescing": [
+            "warn",
+            { ignoreIfStatements: true },
+          ],
+          "@typescript-eslint/prefer-for-of": "warn",
+          "@typescript-eslint/prefer-includes": "warn",
+          "@typescript-eslint/prefer-find": "error",
+          "@typescript-eslint/no-explicit-any": "warn",
+          "@typescript-eslint/ban-ts-comment": "warn",
+          "@typescript-eslint/no-unused-vars": [
+            "error",
+            { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+          ],
+          "@typescript-eslint/consistent-type-imports": [
+            "error",
+            {
+              prefer: "type-imports",
+              fixStyle: "inline-type-imports",
+            },
+          ],
+          "@typescript-eslint/no-floating-promises": "error",
+          "@typescript-eslint/no-misused-promises": "error",
+          "@typescript-eslint/naming-convention": [
+            "error",
+            {
+              selector: "interface",
+              format: ["PascalCase"],
+              prefix: ["I"],
+            },
+            {
+              selector: "typeAlias",
+              format: ["PascalCase"],
+            },
+            {
+              selector: "enum",
+              format: ["PascalCase"],
+            },
+          ],
+          "@typescript-eslint/no-empty-function": "error",
+          "@typescript-eslint/no-useless-constructor": "error",
+          "@typescript-eslint/no-use-before-define": "error",
+          "@typescript-eslint/no-require-imports": "off",
+
+          // prettier
+          "prettier/prettier": "error",
+        },
+      },
+      prettierConfig,
     );
   }
 
   public static createTestRules() {
-    return tseslint.config({
-      files: [
-        "**/*.{test,spec}.{js,jsx,ts,tsx}",
-        "**/tests/**",
-        "**/test/**",
-        "**/__tests__/**",
-      ],
-      languageOptions: {
-        globals: {
-          ...globals.jest,
+    return tseslint.config(
+      {
+        files: [
+          "**/*.{test,spec}.{js,jsx,ts,tsx}",
+          "**/tests/**",
+          "**/test/**",
+          "**/__tests__/**",
+        ],
+        languageOptions: {
+          globals: {
+            ...globals.jest,
+          },
+        },
+        rules: {
+          // Relaxed rules for test files
+          "@typescript-eslint/no-explicit-any": "off",
+          "@stylistic/max-len": "off",
+          "@typescript-eslint/no-non-null-assertion": "off",
         },
       },
-      rules: {
-        // Relaxed rules for test files
-        "@typescript-eslint/no-explicit-any": "off",
-        "@stylistic/max-len": "off",
-        "@typescript-eslint/no-non-null-assertion": "off",
-      },
-    },
-      prettierConfig
+      prettierConfig,
     );
   }
 }


### PR DESCRIPTION
Changes:
- replace formatting rules with Prettier (closes #9)
- adds Vue rules (closes #8)
- splits base configs into 3 (this change is why this is a major version bump)
- some minor rule changes for rules that were more of an annoyance than anything else (like naming schemes rules)